### PR TITLE
シーンでのON/OFFの切り替え

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,37 +38,55 @@ class NatureRemoAircon {
   }
 
   _updateTargetAppliance(params, callback) {
-    this.log('making request for update');
-    const options = Object.assign({}, DEFAULT_REQUEST_OPTIONS, {
-        uri: `/appliances/${this.record.id}/aircon_settings`,
-        headers: {'authorization': `Bearer ${this.access_token}`},
-        method: 'POST',
-        form: params
-      }
-    );
-    request(options, (error, response, body) => {
-      this.log('got reponse for update');
-      if (error || body === null) {
-        this.log(`failed to update: ${error}, ${body}`);
-        callback('failed to update');
-        return;
-      }
-      let json;
-      try {
-        json = JSON.parse(body);
-      } catch (e) {
-        json = null;
-      }
-      if (json === null || 'code' in json) {
-        // 'code' is returned when e.g., unsupported temperature or mode
-        this.log(`server returned error: ${body}`);
-        callback('server returned error');
-        return
-      }
+    this.log(`making request for update: ${JSON.stringify(params)}`);
+    this.requestParams = Object.assign({}, this.requestParams, params);
+
+    if (!this.requestPromise) {
+      this.requestPromise = new Promise((resolve, reject) => {
+        setTimeout(() => {
+          this.log(`request to server: ${JSON.stringify(this.requestParams)}`);
+          const options = Object.assign({
+            'button': this.record.settings.button
+          }, DEFAULT_REQUEST_OPTIONS, {
+            uri: `/appliances/${this.record.id}/aircon_settings`,
+            headers: {'authorization': `Bearer ${this.access_token}`},
+            method: 'POST',
+            form: this.requestParams
+          });
+          request(options, (error, response, body) => {
+            this.log('got reponse for update');
+            if (error || body === null) {
+              this.log(`failed to update: ${error}, ${body}`);
+              reject('failed to update');
+              return;
+            }
+            let json;
+            try {
+              json = JSON.parse(body);
+            } catch (e) {
+              json = null;
+            }
+            if (json === null || 'code' in json) {
+              // 'code' is returned when e.g., unsupported temperature or mode
+              this.log(`server returned error: ${body}`);
+              reject('server returned error');
+              return;
+            }
+            resolve(json)
+          });
+          delete this.requestPromise
+          delete this.requestParams
+        }, 100)
+      });
+    }
+
+    this.requestPromise.then((json) => {
       this.record.settings = json;
       this._notifyLatestValues();
       callback();
-    });
+    }).catch((reason) => {
+      callback(reason)
+    })
   }
 
   _refreshTargetAppliance() {
@@ -264,13 +282,16 @@ class NatureRemoAircon {
   }
 
   getTargetTemperature(callback) {
-    callback(null, this.record.settings.temp);
+    if (!this.record.settings || !this.record.settings.temp) {
+      callback('assertion error');
+    } else {
+      callback(null, this.record.settings.temp);
+    }
   }
 
   setTargetTemperature(value, callback) {
     const params = {
-        'temperature': value.toString(),
-        'button': this.record.settings.button,
+        'temperature': value.toString()
     };
     this._updateTargetAppliance(params, callback);
   }

--- a/index.js
+++ b/index.js
@@ -44,10 +44,11 @@ class NatureRemoAircon {
     if (!this.requestPromise) {
       this.requestPromise = new Promise((resolve, reject) => {
         setTimeout(() => {
+          this.requestParams = Object.assign({'button': this.record.settings.button}, this.requestParams);
+
           this.log(`request to server: ${JSON.stringify(this.requestParams)}`);
-          const options = Object.assign({
-            'button': this.record.settings.button
-          }, DEFAULT_REQUEST_OPTIONS, {
+
+          const options = Object.assign({}, DEFAULT_REQUEST_OPTIONS, {
             uri: `/appliances/${this.record.id}/aircon_settings`,
             headers: {'authorization': `Bearer ${this.access_token}`},
             method: 'POST',


### PR DESCRIPTION
このプラグインを使用してHomeアプリに設定したエアコンに対して、
シーンを用いてON/OFFの切り替えを行えるように対応します

現状、シーンを使用してエアコンを操作すると、
`モードの変更` と `温度の変更` が別命令としてHomeBridgeに連携されるようで、
以下のログのような動きになってしまいます。
([ここ](https://github.com/kmaehashi/homebridge-nature-remo-aircon/blob/master/index.js#L41)のログを変更してパラメータをわかりやすくしています)

**エアコンがONの状態で、OFF(26℃)にするシーンを動作させた場合**

```
[エアコン] making request for update {"button":"power-off"}
[エアコン] making request for update {"temperature":"26","button":""}
[エアコン] got reponse for update
[エアコン] notifying values: {"temp":"26","mode":"warm","vol":"3","dir":"","button":"power-off","updated_at":"2019-02-02T18:23:46Z"}
[エアコン] got reponse for update
[エアコン] notifying values: {"temp":"26","mode":"warm","vol":"3","dir":"","button":"","updated_at":"2019-02-02T18:23:46Z"}
```

**エアコンがOFFの状態で、ON(26℃)にするシーンを動作させた場合**
```
[エアコン] making request for update {"button":"","operation_mode":"warm"}
[エアコン] making request for update {"temperature":"26","button":"power-off"}
[エアコン] got reponse for update
[エアコン] notifying values: {"temp":"26","mode":"warm","vol":"3","dir":"","button":"","updated_at":"2019-02-02T18:26:06Z"}
[エアコン] got reponse for update
[エアコン] notifying values: {"temp":"26","mode":"warm","vol":"3","dir":"","button":"power-off","updated_at":"2019-02-02T18:26:06Z"}
```

温度の変更を処理する際に、
[ここ](https://github.com/kmaehashi/homebridge-nature-remo-aircon/blob/master/index.js#L273)で`'button': this.record.settings.button,` としているのは、**エアコンをオフにした状態で温度変更してもエアコンをオンにしない**ため(`button`を設定せずにサーバにリクエストすると`"button":""` として扱われ勝手にエアコンがオンになるから？)だと思いますが、
`モードの変更` → `温度の変更` とHomeアプリが命令した場合に `温度の変更` で `以前のbuttonの状態(モードの変更する前の状態)`を見てしまっているため、
状態の不整合が起こってしまっています(`モードの変更`時に変更したbuttonがその時点では`this.record.settings`に保存されていないため)

対応の方針としては
- そもそも、`モードの変更` と `温度の変更` が別命令として連携された場合に、サーバに対して2回リクエストする必要もないので、`モードの変更` と `温度の変更` をマージして処理をする（サーバへのリクエストを若干遅延する）、
- `button` に設定する値を、マージ後のパラメータに`button`が存在していない場合のみ`以前のbuttonの状態(this.record.settings.button)`を設定する

と考えました。

あと、homebridge起動時にAPIエラーで温度が取得できなかった場合に`getTargetTemperature`でクラッシュする場合があるので、確認する処理も入れています。

ご確認お願いします🙇‍♂️

---
以下の環境で問題を確認していますが、環境次第で問題が起きない可能性もあります。
端末 iPhone7
バージョン 12.1.2 (16C104)
モデル NNCV2J/A

```
{
  "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
  "device": {
    "name": "リビングのRemo",
    "id": "xxxxxxxxxxxxxxx",
    "created_at": "2018-12-04T06:05:54Z",
    "updated_at": "2019-02-02T18:21:46Z",
    "mac_address": "xxxxxxxxxxxxxxxx",
    "serial_number": "xxxxxxxxxxxxxxxxxxxxxxx",
    "firmware_version": "Remo/1.0.62-gabbf5bd",
    "temperature_offset": 0,
    "humidity_offset": 0
  },
  "model": {
    "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
    "manufacturer": "daikin",
    "remote_name": "xxxxxxxxx",
    "series": "Daikin AC",
    "name": "Daikin AC 003",
    "image": "ico_ac_1"
  },
  "type": "AC",
  "nickname": "エアコン",
  "image": "ico_ac_1",
  "settings": {
    "temp": "26",
    "mode": "warm",
    "vol": "3",
    "dir": "",
    "button": "",
    "updated_at": "2019-02-02T18:21:46Z"
  },
  "aircon": {
    "range": {
      "modes": {
        "auto": {
          "temp": ["-5", "-4", "-3", "-2", "-1", "0", "1", "2", "3", "4", "5"],
          "dir": [""],
          "vol": ["1", "2", "3", "4", "5", "6", "auto"]
        },
        "cool": {
          "temp": ["18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32"],
          "dir": [""],
          "vol": ["1", "2", "3", "4", "5", "6", "auto"]
        },
        "dry": {
          "temp": ["-3", "-2", "-1", "0", "1"],
          "dir": [""],
          "vol": [""]
        },
        "warm": {
          "temp": ["14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"],
          "dir": [""],
          "vol": ["1", "2", "3", "4", "5", "6", "auto"]
        }
      },
      "fixedButtons": ["airdir-swing", "power-off"]
    },
    "tempUnit": "c"
  },
  "signals": []
}
```