### PR TITLE
fix min target temperature being 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,12 +362,12 @@ class NatureRemoAircon {
 
   getMinTargetTemperature() {
     const v = Math.min(...this._getAllTemperatures());
-    return isNaN(v) ? 10.0 : v;
+    return isNaN(v) ? 15.0 : v;
   }
 
   getMaxTargetTemperature() {
     const v = Math.max(...this._getAllTemperatures());
-    return isNaN(v) ? 122.0 : v;
+    return isNaN(v) ? 32.0 : v;
   }
 
   _getAllTemperatures() {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class NatureRemoAircon {
 
     this.service = null;
     this.record = null;
-    this.temperature = 0.0;
+    this.temperature = 25.0;
     this.hasNotifiedConfiguration = false;
     this.updater = new cron.CronJob({
       cronTime: this.schedule,

--- a/index.js
+++ b/index.js
@@ -377,7 +377,7 @@ class NatureRemoAircon {
     const modes = this.record.aircon.range.modes;
 
     for (const mode in modes) {
-      if (! (mode === 'cool' || mode === 'warm' || mode === 'auto')) {
+      if (! (mode === 'cool' || mode === 'warm')) {
         continue;
       }
       const temperatures = modes[mode].temp.filter(t => t.match(/^\d+(\.\d+)?$/)).map(t => parseInt(t));


### PR DESCRIPTION
The temperatures returned by "auto" mode are usually `[ '-2', '-1', '0', '1', '2' ]`, and it makes the min target temperature 0. We should ignored the `temps` of "auto" mode to set correct min target temperature.