### PR TITLE
Skip command request if it actually changes nothing (iOS 13 optimization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Example:
     "accessory": "NatureRemoAircon",
     "name": "Air Conditioner",
     "access_token": "xxxxxxxxx_xxxxxxxxxxxxxxx_x_xxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "appliance_id": ""
+    "appliance_id": "",
+    "skip_command_request_if_no_change": true
   }
 ]
 
@@ -21,3 +22,4 @@ Example:
 
 * Please get your access token at https://home.nature.global/ and set it to `access_token`.
 * `appliance_id` can be left blank if you only have one aircon.
+* `skip_command_request_if_no_change` can be omitted (Default: true). With this option enabled, homebridge-nature-remo-aircon does not send command request (e.g. mode or temperature change) to Nature Remo API if the request will change nothing by comparing it with the current AC state managed by Nature Remo. You may want to turn this false if you control your AC using _both_ Nature Remo and factory hardware remotes in your Home since the latest AC state in the Nature Remo might be incorrect.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class NatureRemoAircon {
     this.appliance_id = config.appliance_id || null;
     this.access_token = config.access_token;
     this.schedule = config.schedule || '* * * * *';
+    this.skip_command_request_if_no_change = config.skip_command_request_if_no_change;
 
     this.service = null;
     this.record = null;
@@ -46,7 +47,7 @@ class NatureRemoAircon {
   }
 
   _updateTargetAppliance(params, callback) {
-    if (!this._willRequestChangeApplianceState(params)) {
+    if (this.skip_command_request_if_no_change && !this._willRequestChangeApplianceState(params)) {
       this.log(`skipping request for update since it won't change the appliance state: ${JSON.stringify(params)}`);
       callback();
       return;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,14 @@ const DEFAULT_REQUEST_OPTIONS = {
   method: 'GET'
 };
 
+const RESPONSE_KEYS_BY_REQUEST_KEY = {
+  'temperature': 'temp',
+  'operation_mode': 'mode',
+  'air_volume': 'vol',
+  'air_direction': 'dir',
+  'button': 'button'
+}
+
 let hap;
 
 module.exports = homebridge => {
@@ -38,6 +46,12 @@ class NatureRemoAircon {
   }
 
   _updateTargetAppliance(params, callback) {
+    if (!this._willRequestChangeApplianceState(params)) {
+      this.log(`skipping request for update since it won't change the appliance state: ${JSON.stringify(params)}`);
+      callback();
+      return;
+    }
+
     this.log(`making request for update: ${JSON.stringify(params)}`);
     this.requestParams = Object.assign({}, this.requestParams, params);
 
@@ -88,6 +102,24 @@ class NatureRemoAircon {
     }).catch((reason) => {
       callback(reason)
     })
+  }
+
+  _willRequestChangeApplianceState(requestParams) {
+    const currentState = this.record && this.record.settings;
+
+    if (!currentState) {
+      return true;
+    }
+
+    for (let requestKey of Object.keys(requestParams)) {
+      const requestValue = requestParams[requestKey];
+      const currentValue = currentState[RESPONSE_KEYS_BY_REQUEST_KEY[requestKey]];
+      if (requestValue !== currentValue) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   _refreshTargetAppliance() {


### PR DESCRIPTION
The Home app on iOS 13 always sends command requests to Homebridge every time opening a thermostat control panel even without actual user operations. This causes unnecessary requests to Nature Remo and annoying beep sound with most ACs.

With this patch, any requests from HomeKit that change nothing will be skipped. If some users need to preserve the old behavior (because they use both Nature Remo and hardware remote in their home), they need to set new configuration option `skip_command_request_if_no_change` to false.

Please watch this video for the actual behavior: https://www.youtube.com/watch?v=kqR1Yg93SAA